### PR TITLE
Improved the EnumerateFunction class for q=1

### DIFF
--- a/lib/src/Base/Func/EnumerateFunction.cxx
+++ b/lib/src/Base/Func/EnumerateFunction.cxx
@@ -54,7 +54,8 @@ EnumerateFunction::EnumerateFunction(const UnsignedInteger dimension,
                                      const NumericalScalar q)
   : TypedInterfaceObject<EnumerateFunctionImplementation>(new HyperbolicAnisotropicEnumerateFunction(dimension, q))
 {
-  // Nothing to do
+  // If q == 1.0 instanciate a LinearEnumerateFunction which is much modre efficient
+  if (q == 1.0) *this = EnumerateFunction(dimension);
 }
 
 /* Parameter constructor */


### PR DESCRIPTION
When q=1 and all the weights are equal, the HyperbolicAnisotropicEnumerateFunction reduces to the LinearEnumerateFunction, which is much more efficient.
