### PR TITLE
Improved Kriging performance

### DIFF
--- a/lib/src/Base/Stat/CovarianceModelImplementation.cxx
+++ b/lib/src/Base/Stat/CovarianceModelImplementation.cxx
@@ -196,8 +196,24 @@ Scalar CovarianceModelImplementation::computeAsScalar (const Point & s,
 Scalar CovarianceModelImplementation::computeAsScalar(const Collection<Scalar>::const_iterator & s_begin,
     const Collection<Scalar>::const_iterator & t_begin) const
 {
+  // Work on iterators
+  // Major 1D models implement the computeStandardRepresentative method
+  // We rely on this previous method to evaluate the covariance as scalar
+  // Otherwise we build Points & rely on a more global method (exceptions are
+  // local implementations)
   if (outputDimension_ != 1) throw NotDefinedException(HERE) << "Error: the covariance model is of dimension=" << outputDimension_ << ", expected dimension=1.";
-  return outputCovariance_(0, 0) * computeStandardRepresentative(s_begin, t_begin);
+  if (definesComputeStandardRepresentative_) return outputCovariance_(0, 0) * computeStandardRepresentative(s_begin, t_begin);
+  // Case we do not define computeStandardRepresentative
+  Collection<Scalar>::const_iterator s_it = s_begin;
+  Collection<Scalar>::const_iterator t_it = t_begin;
+  Point s(inputDimension_, 0.0);
+  Point t(inputDimension_, 0.0);
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i, ++s_it, ++t_it)
+  {
+    s[i] = *s_it;
+    t[i] = *t_it;
+  }
+  return computeAsScalar(s, t);
 }
 
 /* Computation of the covariance function */

--- a/lib/src/Base/Stat/SquaredExponential.cxx
+++ b/lib/src/Base/Stat/SquaredExponential.cxx
@@ -64,9 +64,12 @@ SquaredExponential * SquaredExponential::clone() const
 Scalar SquaredExponential::computeStandardRepresentative(const Point & tau) const
 {
   if (tau.getDimension() != inputDimension_) throw InvalidArgumentException(HERE) << "Error: expected a shift of dimension=" << inputDimension_ << ", got dimension=" << tau.getDimension();
-  Point tauOverTheta(inputDimension_);
-  for (UnsignedInteger i = 0; i < inputDimension_; ++i) tauOverTheta[i] = tau[i] / scale_[i];
-  const Scalar tauOverTheta2 = tauOverTheta.normSquare();
+  Scalar tauOverTheta2 = 0.0;
+  for (UnsignedInteger i = 0; i < inputDimension_; ++i)
+  {
+    const Scalar dx = tau[i] / scale_[i];
+    tauOverTheta2 += dx * dx;
+  }
   return tauOverTheta2 <= SpecFunc::ScalarEpsilon ? 1.0 + nuggetFactor_ : exp(-0.5 * tauOverTheta2);
 }
 

--- a/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingEvaluation.cxx
+++ b/lib/src/Uncertainty/Algorithm/MetaModel/Kriging/KrigingEvaluation.cxx
@@ -151,7 +151,7 @@ struct KrigingEvaluationPointFunctor1D
                                   const KrigingEvaluation & evaluation)
     : input_(input)
     , evaluation_(evaluation)
-    , accumulator_(evaluation.getOutputDimension())
+    , accumulator_(0.0)
   {}
 
   KrigingEvaluationPointFunctor1D(const KrigingEvaluationPointFunctor1D & other,
@@ -164,7 +164,9 @@ struct KrigingEvaluationPointFunctor1D
   inline void operator()( const TBB::BlockedRange<UnsignedInteger> & r )
   {
     for (UnsignedInteger i = r.begin(); i != r.end(); ++i)
-      accumulator_ += evaluation_.covarianceModel_.computeAsScalar(input_, evaluation_.inputSample_[i]) * evaluation_.gamma_(i, 0);
+    {
+      accumulator_ += evaluation_.covarianceModel_.getImplementation()->computeAsScalar(input_.begin(), evaluation_.inputSample_.getImplementation()->data_begin() + i * input_.getDimension()) * evaluation_.gamma_(i, 0);
+    }
   } // operator()
 
   inline void join(const KrigingEvaluationPointFunctor1D & other)
@@ -272,7 +274,7 @@ struct KrigingEvaluationSampleFunctor1D
     for (UnsignedInteger i = 0; i != size; ++i)
     {
       for (UnsignedInteger j = 0; j < trainingSize_; ++j)
-        value += evaluation_.covarianceModel_.getImplementation()->computeAsScalar(input_[start + i], evaluation_.inputSample_[j]) * evaluation_.gamma_(j, 0);
+        value += evaluation_.covarianceModel_.getImplementation()->computeAsScalar(input_.getImplementation()->data_begin() + (start + i) * inputDimension, evaluation_.inputSample_.getImplementation()->data_begin() + (j * inputDimension) ) * evaluation_.gamma_(j, 0);
       output_(start + i, 0) = value;
     }
   } // operator()

--- a/lib/src/Uncertainty/Algorithm/Optimization/EfficientGlobalOptimization.cxx
+++ b/lib/src/Uncertainty/Algorithm/Optimization/EfficientGlobalOptimization.cxx
@@ -22,6 +22,7 @@
 #include "openturns/PersistentObjectFactory.hxx"
 #include "openturns/Cobyla.hxx"
 #include "openturns/SpecFunc.hxx"
+#include "openturns/DistFunc.hxx"
 #include "openturns/KrigingAlgorithm.hxx"
 #include "openturns/MultiStart.hxx"
 #include "openturns/ComposedDistribution.hxx"
@@ -92,7 +93,7 @@ public:
     const Scalar sk = sqrt(sk2);
     if (!SpecFunc::IsNormal(sk)) return Point(1, -SpecFunc::MaxScalar);
     const Scalar ratio = fmMk / sk;
-    Scalar ei = fmMk * normal_.computeCDF(ratio) + sk * normal_.computePDF(ratio);
+    Scalar ei = fmMk * DistFunc::pNormal(ratio) + sk * DistFunc::pNormal(ratio);
     if (noiseModel_.getOutputDimension() == 1) // if provided
     {
       const Scalar noiseVariance = noiseModel_(x)[0];
@@ -132,7 +133,6 @@ public:
   }
 
 protected:
-  Normal normal_;
   Scalar optimalValue_;
   KrigingResult metaModelResult_;
   Function noiseModel_;


### PR DESCRIPTION
 - Avoide useless creation/destruction of Point
   In KrigingEvaluation, we rely on computeAsScalar(it, it)
   This last one relies on computeStandardRepresentative(it, it). If model
   does not implement the computeStandardRepresentative then we explicitly
   build Point and provide the final output
  - Small improvements in SquaredExponential : do not create Point to
  compute norm, compute it directly
  - Avoid usage of Normal distribution in EGO : use DistFunc instead